### PR TITLE
docs(readme): 修复失效的 Star History 图表链接

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,4 +201,4 @@ This project is released under the AGPL-3.0 license. For the full legal text, pl
 In addition, this project explicitly prohibits any form of commercial use, including but not limited to selling this software, using this software or its modified versions as part of paid services, or profiting directly or indirectly in any manner through this software. Any violation may result in legal liability pursued by the author in accordance with applicable laws.
 
 ## ⭐ Star History
- [![Star History Chart](https://api.star-history.com/svg?repos=zhashut/goread&type=Date)](https://star-history.com/#zhashut/goread&Date)
+ [![Star History Chart](https://star-history.dera.page/svg?repos=zhashut/goread&type=Date)](https://star-history.dera.page/#zhashut/goread&Date)

--- a/README.zh.md
+++ b/README.zh.md
@@ -198,4 +198,4 @@ GoRead 仍在持续迭代中，欢迎你：
 在此基础上，本项目明确禁止任何形式的商业使用，包括但不限于销售本软件、将本软件或其修改版本用于收费服务，或以任何直接或间接方式通过本软件牟利。如有违反，作者保留依法追究相关法律责任的权利。
 
 ## ⭐ Star History
- [![Star History Chart](https://api.star-history.com/svg?repos=zhashut/goread&type=Date)](https://star-history.com/#zhashut/goread&Date)
+ [![Star History Chart](https://star-history.dera.page/svg?repos=zhashut/goread&type=Date)](https://star-history.dera.page/#zhashut/goread&Date)


### PR DESCRIPTION
当前 README 中的 Star History 图表由于上游接口限制已失效，无法正常展示星标历史。本次更新将图表直接指向可用的新服务域名，确保图表恢复正常显示。修改已同步应用到 README.md 与 README.zh.md。